### PR TITLE
Add CLAUDE.md with a push-before-pre-commit rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md
+
+## push 前のルール
+
+コミットを push する前に、必ずローカルで pre-commit を実行して確認すること。
+
+```zsh
+pre-commit run --files <変更したファイル...>
+```
+
+現状、システムの `python3` が古く（3.9.6、yamllint の要求する `>=3.10` を満たさない）、
+`yamllint` フックの環境構築が失敗する。YAML を変更していない場合は `SKIP=yamllint` で
+迂回してよいが、YAML ファイルを変更した場合は迂回せず、`python3` を新しくしてから確認する。
+
+```zsh
+SKIP=yamllint pre-commit run --files <変更したファイル...>
+```

--- a/rcrc
+++ b/rcrc
@@ -1,3 +1,3 @@
-EXCLUDES=".devcontainer/* .github/* .npm/* .pre-commit-cache/* node_modules/* .editorconfig .gitignore .node-version .yamllint dprint.json LICENSE package.json package-lock.json README.md renovate.json"
+EXCLUDES=".devcontainer/* .github/* .npm/* .pre-commit-cache/* node_modules/* .editorconfig .gitignore .node-version .yamllint CLAUDE.md dprint.json LICENSE package.json package-lock.json README.md renovate.json"
 DOTFILES_DIRS="$HOME/dotfiles-local $HOME/dotfiles"
 COPY_ALWAYS="git_template/HEAD"


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` documenting a repo rule: run `pre-commit` locally before pushing, with a note that `yamllint`'s hook currently fails to build on this machine (system `python3` is 3.9.6, yamllint requires `>=3.10`) and can be skipped with `SKIP=yamllint` as long as no YAML files changed.
- Excludes `CLAUDE.md` from `rcup`'s symlink targets in `rcrc` (same treatment as `README.md`/`LICENSE`), verified with `rcup -g` (dry-run) that it no longer resolves to `~/.CLAUDE.md`.
- Split out of #109 because that PR was already merged before this commit was pushed.

## Test plan
- [x] `SKIP=yamllint pre-commit run --files CLAUDE.md rcrc` → `dprint fmt` passed
- [x] `rcup -g -v` dry-run confirms `CLAUDE.md` is not linked into `$HOME`

🤖 Generated with [Claude Code](https://claude.com/claude-code)