### PR TITLE
zshでclaudeコマンドがなければ自動インストール

### DIFF
--- a/zsh/configs/claude.zsh
+++ b/zsh/configs/claude.zsh
@@ -1,0 +1,3 @@
+if ! which claude &>/dev/null; then
+    curl -fsSL https://claude.ai/install.sh | bash
+fi

--- a/zsh/configs/claude.zsh
+++ b/zsh/configs/claude.zsh
@@ -1,3 +1,8 @@
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+
 if ! which claude &>/dev/null; then
     curl -fsSL https://claude.ai/install.sh | bash
 fi


### PR DESCRIPTION
## Summary
- `zsh/configs/claude.zsh` を追加し、`claude` コマンドが見つからない場合にシェル起動時に公式インストーラー (`curl -fsSL https://claude.ai/install.sh | bash`) を実行するようにした
- 既存の `_sheldon.zsh` / `starship.zsh` と同じ `which` によるコマンド存在チェックのパターンに合わせている

## Test plan
- [x] `SKIP=yamllint pre-commit run --files zsh/configs/claude.zsh` が通ることを確認