### PR TITLE
Fix crit plugin update to use qualified plugin@marketplace name

### DIFF
--- a/scripts/update-plugins.sh
+++ b/scripts/update-plugins.sh
@@ -8,4 +8,4 @@ if ! which claude &>/dev/null; then
 fi
 
 claude plugin marketplace update
-claude plugin update crit
+claude plugin update crit@crit


### PR DESCRIPTION
## Summary
- `scripts/update-plugins.sh` called `claude plugin update crit`, but `claude plugin update` requires the `<plugin>@<marketplace>` form. This made the update check fail with "Plugin not found" even though crit is correctly installed and enabled (`crit@crit`, v1.8.1).
- Change the call to `claude plugin update crit@crit`, matching the qualified name used everywhere else (`claude plugin list`, `claude plugin install crit@crit`).

## Test plan
- [x] Ran `~/.scripts/update-plugins.sh` (symlinked to this script) after the fix — marketplaces update and the crit update check both succeed cleanly.
- [x] Ran `SKIP=yamllint pre-commit run --files scripts/update-plugins.sh` per this repo's CLAUDE.md rule (yamllint skipped since no YAML changed; only shell script touched).