### PR TITLE
コード解析にもとづく改善（scapple堅牢化・zsh起動軽量化ほか）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
-      "Read(//Users/okhiroyuki/dotfiles/**)",
+      "Read(~/dotfiles/**)",
       "Bash(lsrc *)",
       "Bash(pre-commit run *)",
       "Bash(git add:*)",

--- a/.github/workflows/scapple.yml
+++ b/.github/workflows/scapple.yml
@@ -1,0 +1,36 @@
+---
+name: scapple
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    paths:
+      - "tools/scapple/**"
+      - ".github/workflows/scapple.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/scapple/**"
+      - ".github/workflows/scapple.yml"
+
+defaults:
+  run:
+    working-directory: tools/scapple
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Enable pnpm via corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+      - name: Test
+        run: pnpm test

--- a/scripts/setup-claude.sh
+++ b/scripts/setup-claude.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-# claude CLI と共有プラグインを導入する初回セットアップ。
+# claude CLI と、settings.json で有効化されたプラグインを導入する初回セットアップ。
 # 対話シェル起動を遅くしないため、_claude.zsh からは自動実行せず、
 # 新しいマシンで一度だけ手動で実行する。
+#
+# プラグイン一覧はハードコードせず ~/.claude/settings.json から導出する。
+# 新しいプラグインを増やすときは settings.json の enabledPlugins /
+# extraKnownMarketplaces に追記するだけでよく、このスクリプトの変更は不要。
 
 set -euo pipefail
 
@@ -22,20 +26,31 @@ if ! command -v claude >/dev/null 2>&1; then
   exit 1
 fi
 
-# 導入済みプラグイン一覧は1回だけ取得して使い回す（plugin list はノード起動を伴い重い）。
-installed_plugins="$(claude plugin list 2>/dev/null || true)"
+settings_file="$HOME/.claude/settings.json"
 
-ensure_plugin() {
-  local plugin_ref="$1" marketplace_repo="$2"
-  if ! printf '%s\n' "$installed_plugins" | grep -q "$plugin_ref"; then
-    claude plugin marketplace add "$marketplace_repo"
+if command -v jq >/dev/null 2>&1 && [ -f "$settings_file" ]; then
+  # 導入済みプラグイン一覧は1回だけ取得して使い回す（plugin list はノード起動を伴い重い）。
+  installed_plugins="$(claude plugin list 2>/dev/null || true)"
+
+  # enabledPlugins（値が true）のプラグインを順に導入する。
+  # plugin_ref は "<plugin>@<marketplace>" 形式。marketplace の GitHub リポジトリは
+  # extraKnownMarketplaces から引く（未登録なら marketplace add を省略して install だけ試す）。
+  while IFS= read -r plugin_ref; do
+    [ -n "$plugin_ref" ] || continue
+    if printf '%s\n' "$installed_plugins" | grep -q "$plugin_ref"; then
+      continue
+    fi
+    marketplace_name="${plugin_ref##*@}"
+    marketplace_repo="$(jq -r --arg mp "$marketplace_name" \
+      '.extraKnownMarketplaces[$mp].source.repo // empty' "$settings_file")"
+    if [ -n "$marketplace_repo" ]; then
+      claude plugin marketplace add "$marketplace_repo"
+    fi
     claude plugin install "$plugin_ref"
-  fi
-}
-
-ensure_plugin "crit@crit" "tomasz-tomczyk/crit"
-ensure_plugin "product-skills@claude-code-skills" "alirezarezvani/claude-skills"
-ensure_plugin "skill-scanner@skillplugs" "skillplugs/plugins"
+  done < <(jq -r '.enabledPlugins // {} | to_entries[] | select(.value == true) | .key' "$settings_file")
+else
+  echo "jq または $settings_file が見つからないため、プラグインの自動導入をスキップしました。" >&2
+fi
 
 # 導入済みプラグインを最新へ更新する。
 "$(dirname "$0")/update-plugins.sh"

--- a/scripts/setup-claude.sh
+++ b/scripts/setup-claude.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# claude CLI と共有プラグインを導入する初回セットアップ。
+# 対話シェル起動を遅くしないため、_claude.zsh からは自動実行せず、
+# 新しいマシンで一度だけ手動で実行する。
+
+set -euo pipefail
+
+# claude CLI は ~/.local/bin に入るため、このスクリプト実行中のみ PATH に追加する。
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "claude CLI をインストールします..."
+  curl -fsSL https://claude.ai/install.sh | bash
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "claude CLI のインストールに失敗しました。" >&2
+  exit 1
+fi
+
+# 導入済みプラグイン一覧は1回だけ取得して使い回す（plugin list はノード起動を伴い重い）。
+installed_plugins="$(claude plugin list 2>/dev/null || true)"
+
+ensure_plugin() {
+  local plugin_ref="$1" marketplace_repo="$2"
+  if ! printf '%s\n' "$installed_plugins" | grep -q "$plugin_ref"; then
+    claude plugin marketplace add "$marketplace_repo"
+    claude plugin install "$plugin_ref"
+  fi
+}
+
+ensure_plugin "crit@crit" "tomasz-tomczyk/crit"
+ensure_plugin "product-skills@claude-code-skills" "alirezarezvani/claude-skills"
+ensure_plugin "skill-scanner@skillplugs" "skillplugs/plugins"
+
+# 導入済みプラグインを最新へ更新する。
+"$(dirname "$0")/update-plugins.sh"

--- a/scripts/update-plugins.sh
+++ b/scripts/update-plugins.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if ! which claude &>/dev/null; then
+if ! command -v claude >/dev/null 2>&1; then
     echo "claude CLI not found" >&2
     exit 1
 fi
@@ -10,7 +10,7 @@ fi
 claude plugin marketplace update
 
 settings_file="$HOME/.claude/settings.json"
-if which jq &>/dev/null && [ -f "$settings_file" ]; then
+if command -v jq >/dev/null 2>&1 && [ -f "$settings_file" ]; then
     for plugin in $(jq -r '.enabledPlugins // {} | keys[]' "$settings_file"); do
         claude plugin update "$plugin"
     done

--- a/tools/scapple/bin/scapple.ts
+++ b/tools/scapple/bin/scapple.ts
@@ -20,8 +20,19 @@ if (values.help || positionals.length === 0) {
   process.exit(0);
 }
 
+if (values.format !== "json" && values.format !== "text") {
+  console.error(`未知の形式: ${values.format}（json | text のいずれかを指定してください）`);
+  process.exit(1);
+}
+
 const filepath = positionals[0];
-const doc = parseScap(filepath);
+let doc;
+try {
+  doc = parseScap(filepath);
+} catch (e) {
+  console.error(`エラー: ${filepath} を解析できませんでした: ${(e as Error).message}`);
+  process.exit(1);
+}
 
 if (values.format === "text") {
   const byId = new Map(doc.notes.map((n) => [n.id, n.text]));

--- a/tools/scapple/pnpm-workspace.yaml
+++ b/tools/scapple/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 ---
-# esbuild（tsx の依存）のビルドを許可する。未宣言だと pnpm のインストールが
-# ビルドスクリプトを無視し、pnpm 11 の CI では ERR_PNPM_IGNORED_BUILDS で失敗する。
-onlyBuiltDependencies:
-  - esbuild
+# esbuild（tsx の依存）のビルドを許可する。pnpm 11 はビルドスクリプトを持つ依存を
+# 見つけると allowBuilds の雛形を書き出して承認を求め、未承認のままだと
+# ERR_PNPM_IGNORED_BUILDS でインストールに失敗する。true にして明示的に許可する。
+allowBuilds:
+  esbuild: true

--- a/tools/scapple/pnpm-workspace.yaml
+++ b/tools/scapple/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 ---
-# esbuild（tsx の依存）のビルドスクリプトは実行しなくてもtsx/テストが動くため、
-# 明示的に無視する。未宣言だと pnpm 11 の CI インストールが ERR_PNPM_IGNORED_BUILDS で失敗する。
-ignoredBuiltDependencies:
+# esbuild（tsx の依存）のビルドを許可する。未宣言だと pnpm のインストールが
+# ビルドスクリプトを無視し、pnpm 11 の CI では ERR_PNPM_IGNORED_BUILDS で失敗する。
+onlyBuiltDependencies:
   - esbuild

--- a/tools/scapple/pnpm-workspace.yaml
+++ b/tools/scapple/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 ---
-allowBuilds:
-  esbuild: set this to true or false
+# esbuild（tsx の依存）のビルドスクリプトは実行しなくてもtsx/テストが動くため、
+# 明示的に無視する。未宣言だと pnpm 11 の CI インストールが ERR_PNPM_IGNORED_BUILDS で失敗する。
+ignoredBuiltDependencies:
+  - esbuild

--- a/tools/scapple/src/id-range.test.ts
+++ b/tools/scapple/src/id-range.test.ts
@@ -23,3 +23,17 @@ test("降順の範囲もパースする", () => {
 test("数値化できない断片は無視する", () => {
   assert.deepEqual(parseIdRange("1, x, 3"), [1, 3]);
 });
+
+test("片側が欠けた範囲は不正値として捨てる", () => {
+  assert.deepEqual(parseIdRange("5-"), []);
+  assert.deepEqual(parseIdRange("-3"), []);
+  assert.deepEqual(parseIdRange("2, 5-, 7"), [2, 7]);
+});
+
+test("ハイフンが2つ以上ある断片は捨てる", () => {
+  assert.deepEqual(parseIdRange("1-2-3"), []);
+});
+
+test("上限を超える巨大な範囲は展開しない", () => {
+  assert.deepEqual(parseIdRange("1-100000000"), []);
+});

--- a/tools/scapple/src/id-range.ts
+++ b/tools/scapple/src/id-range.ts
@@ -2,6 +2,9 @@
  * Scappleの ConnectedNoteIDs / PointsToNoteIDs は "1-3,5" のように
  * カンマ区切り・ハイフン範囲混在の文字列でIDを表す。
  */
+/** 1つの範囲が展開してよいID数の上限。壊れた/悪意ある入力による巨大配列確保を防ぐ。 */
+const MAX_RANGE_SIZE = 10_000;
+
 export function parseIdRange(value: string | number | undefined): number[] {
   if (value === undefined || value === "") return [];
 
@@ -11,15 +14,18 @@ export function parseIdRange(value: string | number | undefined): number[] {
     if (!trimmed) continue;
 
     if (trimmed.includes("-")) {
-      const [startStr, endStr] = trimmed.split("-");
-      const start = Number(startStr);
-      const end = Number(endStr);
-      if (Number.isNaN(start) || Number.isNaN(end)) continue;
+      // "1-2-3" のような多重ハイフンや "5-"/"-3" のような片側欠けは不正値として捨てる。
+      const bounds = trimmed.split("-");
+      if (bounds.length !== 2 || bounds[0] === "" || bounds[1] === "") continue;
+      const start = Number(bounds[0]);
+      const end = Number(bounds[1]);
+      if (!Number.isInteger(start) || !Number.isInteger(end)) continue;
+      if (Math.abs(end - start) + 1 > MAX_RANGE_SIZE) continue;
       const step = start <= end ? 1 : -1;
       for (let i = start; step > 0 ? i <= end : i >= end; i += step) ids.push(i);
     } else {
       const id = Number(trimmed);
-      if (!Number.isNaN(id)) ids.push(id);
+      if (Number.isInteger(id)) ids.push(id);
     }
   }
   return ids;

--- a/zsh/configs/_claude.zsh
+++ b/zsh/configs/_claude.zsh
@@ -1,31 +1,21 @@
+# claude CLI は ~/.local/bin に入るため PATH に追加する。
 case ":$PATH:" in
   *":$HOME/.local/bin:"*) ;;
   *) export PATH="$HOME/.local/bin:$PATH" ;;
 esac
 
-if ! which claude &>/dev/null; then
-    curl -fsSL https://claude.ai/install.sh | bash
-fi
-
-if which claude &>/dev/null && ! claude plugin list 2>/dev/null | grep -q "crit@crit"; then
-    claude plugin marketplace add tomasz-tomczyk/crit
-    claude plugin install crit@crit
-fi
-
-if which claude &>/dev/null && ! claude plugin list 2>/dev/null | grep -q "product-skills@claude-code-skills"; then
-    claude plugin marketplace add alirezarezvani/claude-skills
-    claude plugin install product-skills@claude-code-skills
-fi
-
-if which claude &>/dev/null && ! claude plugin list 2>/dev/null | grep -q "skill-scanner@skillplugs"; then
-    claude plugin marketplace add skillplugs/plugins
-    claude plugin install skill-scanner@skillplugs
-fi
-
-_claude_plugin_update_stamp="$HOME/.cache/claude/plugin-update-stamp"
-if which claude &>/dev/null && { [ ! -f "$_claude_plugin_update_stamp" ] || [ -n "$(find "$_claude_plugin_update_stamp" -mtime +1)" ]; }; then
+# claude 未インストール・プラグイン未導入時のブートストラップは
+# scripts/setup-claude.sh に分離した。リモートスクリプトの自動実行や
+# 起動ごとの plugin list 呼び出しはシェル起動を遅くするため、ここでは行わない。
+if ! command -v claude >/dev/null 2>&1; then
+  echo "claude CLI が見つかりません。~/dotfiles/scripts/setup-claude.sh を実行してください。" >&2
+else
+  # プラグインの更新は1日1回だけ（起動ごとのネットワーク処理を避ける）。
+  _claude_plugin_update_stamp="$HOME/.cache/claude/plugin-update-stamp"
+  if [ ! -f "$_claude_plugin_update_stamp" ] || [ -n "$(find "$_claude_plugin_update_stamp" -mtime +1)" ]; then
     ~/dotfiles/scripts/update-plugins.sh
     mkdir -p "$(dirname "$_claude_plugin_update_stamp")"
     touch "$_claude_plugin_update_stamp"
+  fi
+  unset _claude_plugin_update_stamp
 fi
-unset _claude_plugin_update_stamp

--- a/zsh/configs/_sheldon.zsh
+++ b/zsh/configs/_sheldon.zsh
@@ -1,4 +1,4 @@
-if which sheldon &>/dev/null; then
+if command -v sheldon >/dev/null 2>&1; then
     if [[ ! -f $HOME/.config/sheldon/plugins.toml ]] ; then
         yes | sheldon init --shell zsh
     fi

--- a/zsh/configs/direnv.zsh
+++ b/zsh/configs/direnv.zsh
@@ -1,4 +1,4 @@
 # load direnv if available
-if which direnv &>/dev/null ; then
+if command -v direnv >/dev/null 2>&1 ; then
     eval "$(direnv hook zsh)"
 fi

--- a/zsh/configs/fzf.zsh
+++ b/zsh/configs/fzf.zsh
@@ -1,3 +1,3 @@
-if which fzf &>/dev/null ; then
+if command -v fzf >/dev/null 2>&1 ; then
     [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 fi


### PR DESCRIPTION
## 概要

リポジトリ全体を解析し、影響度の高い順に7点を修正した。scapple CLIの入力堅牢化、zsh起動時のネットワーク処理・セキュリティ改善、CIでのTS検査追加、Claude設定の移植性改善を含む。

## 変更点

### scapple（TypeScript CLI）
- **`parseIdRange` の不正な範囲文字列を弾く**（`fix`）: 片側欠け（`5-` / `-3`）で存在しないIDを生成する、多重ハイフン（`1-2-3`）で末尾を黙って捨てる、上限のない範囲（`1-100000000`）で巨大配列を確保する、の3つのバグを修正。回帰テストを追加。
- **CLIにエラー処理とformat検証を追加**（`feat`）: ファイル不在・不正XMLを人間向けメッセージ＋`exit 1`で報告。未知の`--format`値をエラーにする。

### CI
- **scapple用ワークフローを追加**（`ci`）: `tools/scapple/**` 変更時に corepack で pnpm を用意し、`tsc --noEmit` とテストを実行。パーサの回帰を検知できるようにした。

### zsh / スクリプト
- **claude起動処理を `scripts/setup-claude.sh` に分離**（`refactor`）: 対話シェル起動ごとの `curl | bash` 自動実行と、`claude plugin list` の多重呼び出しを廃止。初回導入（CLI・プラグイン）は手動スクリプトに移し、`_claude.zsh` はPATH追加と日次更新のみに軽量化。
- **`which` を `command -v` に統一**（`refactor`）: fzf / sheldon / direnv / update-plugins.sh。外部コマンド依存を減らし移植性を向上。

### Claude設定
- **`settings.json` のRead許可パスを移植可能に**（`fix`）: ユーザー名決め打ちの絶対パス `//Users/okhiroyuki/dotfiles/**` を `~/dotfiles/**` に変更。

## 検証

- `pnpm test`（13件全パス）、`pnpm exec tsc --noEmit`（エラーなし）
- CLIのエラー処理・format検証・text出力を手動確認
- 変更したシェルスクリプトの `bash -n` 構文チェック、`scapple.yml` の yamllint（`--strict`）、`settings.json` のJSON妥当性を確認

### 未検証・補足
- `dprint fmt` はこの作業環境がプロキシで `plugins.dprint.dev` に到達できず未実行。整形はpre-commit CIで最終担保される。
- 新規追加ファイルは `rcrc` の `EXCLUDES`（`scripts/*` / `.*`）で既にシンボリックリンク対象外のため `EXCLUDES` 変更は不要。`lsrc -d .` は環境にrcm未導入のため未実行。


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFdetFAFH5LPa9T8c8SfZJ)_