### PR TITLE
追加のコード解析改善（starshipキャッシュ堅牢化・gitignore整理ほか）

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -1,18 +1,15 @@
-*.pyc
-*.sw[nop]
+# グローバル(~/.gitignore)は全リポジトリに効くため、OS・エディタのゴミと
+# 「どのリポジトリでも決して追跡しない」ものだけに限定する。
+# プロジェクト構造に依存する無視（log/ tmp/ node_modules/ vendor/ db/*.sqlite3 等）は
+# 各リポジトリの .gitignore に置く。ここに書くと、それらを追跡する別プロジェクトで
+# 意図せずファイルが隠れる事故につながる。
+
+# OS / エディタ
 .DS_Store
-.bundle
-.byebug_history
-.env
-.git/
-/bower_components/
-/log
-/node_modules/
-/tmp
-/vendor
-db/*.sqlite3
-log/*.log
-rerun.txt
-tmp/**/*
+*.sw[nop]
+*.pyc
 /tags
+
+# 機密（どのリポジトリでも誤コミットを防ぐ）
+.env
 .env.devcontainer

--- a/zsh/configs/mise.zsh
+++ b/zsh/configs/mise.zsh
@@ -1,3 +1,3 @@
-if which mise &>/dev/null; then
+if command -v mise >/dev/null 2>&1; then
   eval "$(mise activate zsh)"
 fi

--- a/zsh/configs/starship.zsh
+++ b/zsh/configs/starship.zsh
@@ -1,8 +1,14 @@
-if which starship &>/dev/null ; then
+if command -v starship >/dev/null 2>&1 ; then
     export STARSHIP_CONFIG=~/.starship/config.toml
-    if [ ! -f /tmp/zsh_starship.cache ]; then
-        starship init zsh > /tmp/zsh_starship.cache
-        zcompile /tmp/zsh_starship.cache
+    # キャッシュはユーザー専有ディレクトリに置く。固定名で共有の /tmp に置くと、
+    # 他ユーザーが先に同名ファイルを仕込めば source 経由でコード実行され得る。
+    _starship_cache="${XDG_CACHE_HOME:-$HOME/.cache}/starship/init.zsh"
+    # starship 本体がキャッシュより新しい（アップグレード後など）場合は作り直す。
+    if [ ! -f "$_starship_cache" ] || [ "$(command -v starship)" -nt "$_starship_cache" ]; then
+        mkdir -p "$(dirname "$_starship_cache")"
+        starship init zsh > "$_starship_cache"
+        zcompile "$_starship_cache"
     fi
-    source /tmp/zsh_starship.cache
+    source "$_starship_cache"
+    unset _starship_cache
 fi


### PR DESCRIPTION
## 概要

前回のPR #133 に続く追加レビューで見つかった3点を修正した。starshipキャッシュのセキュリティ・鮮度、グローバルgitignoreの整理、`which`統一の取りこぼし。

## 変更点

### zsh起動
- **starshipキャッシュをユーザー専有ディレクトリに移動**（`fix`）: 固定名の共有 `/tmp/zsh_starship.cache` は、他ユーザーが先に同名ファイルを仕込むと `source` 経由で任意コード実行され得る。`${XDG_CACHE_HOME:-$HOME/.cache}/starship/init.zsh` に移し、starship本体がキャッシュより新しい場合（アップグレード後など）は再生成する鮮度判定も追加。あわせて `which` を `command -v` に統一。
- **`mise.zsh` の `which` を `command -v` に統一**（`refactor`）: 前回PRの統一からの取りこぼしを解消。これでリポジトリ内の `which` 使用はコメント文言を除きなくなった。

### git設定
- **グローバル `gitignore` をOS/エディタ/機密のみに整理**（`chore`）: `log/` `tmp/` `node_modules/` `vendor/` `db/*.sqlite3` などプロジェクト構造に依存する無視パターンを削除。全リポジトリに効くグローバル無視は、それらを追跡する別プロジェクトでファイルを隠す事故につながるため、各リポジトリの `.gitignore` に委ねる。無意味な `.git/` も除去。

## 検証

- 変更した各 zsh ファイルの `bash -n` 構文チェック
- starshipキャッシュの鮮度判定ロジックをシミュレートし、「キャッシュが無い／starship本体が新しい場合のみ再生成、それ以外は再利用」を確認
- `grep` でリポジトリ内の `which` 使用がコメント以外に残っていないことを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFdetFAFH5LPa9T8c8SfZJ)_