### PR TITLE
git/mise/sheldon設定の改善（グローバル無視の配線修正ほか）

### DIFF
--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -30,14 +30,17 @@ rev = "53a26e287fbbe2dcebb3aa1801546c6de32416fa"
 github = "ryutok/rust-zsh-completions"
 tag = "1.16.0"
 
+# zsh-autosuggestions は zsh-syntax-highlighting より前に読み込む（公式推奨）。
+# どちらも defer で遅延ロードし、シェル起動を速くする。
+[plugins.zsh-autosuggestions]
+github = "zsh-users/zsh-autosuggestions"
+tag = "v0.7.0"
+apply = ["defer"]
+
 [plugins.zsh-syntax-highlighting]
 github = "zsh-users/zsh-syntax-highlighting"
 tag = "0.8.0"
 apply = ["defer"]
-
-[plugins.zsh-autosuggestions]
-github = "zsh-users/zsh-autosuggestions"
-tag = "v0.7.0"
 
 [plugins.compinit]
 inline = "autoload -Uz compinit && zsh-defer compinit"

--- a/host-private/config/mise/config.toml
+++ b/host-private/config/mise/config.toml
@@ -1,3 +1,0 @@
-[tools]
-node = "latest"
-pnpm = "latest"

--- a/host-private/gitconfig
+++ b/host-private/gitconfig
@@ -5,7 +5,7 @@
 [fetch]
   prune = true
 [core]
-  excludesfile = ~/.gitignore_global
+  excludesfile = ~/.gitignore
 [ghq]
   root = ~/Documents/src
 [include]


### PR DESCRIPTION
## 概要

追加レビューで見つかった設定の不整合・不要設定・起動高速化の3点を修正した。目玉は、グローバルgitignoreが実際には一切効いていなかった配線ミスの修正。

## 変更点

### git設定
- **`gitconfig` の `excludesfile` を `~/.gitignore` に修正**（`fix`）: rcm はリポジトリの `gitignore` を `~/.gitignore` にsymlinkするが、`core.excludesfile` は実在しない `~/.gitignore_global` を指していた。そのため git はグローバル無視を一切読めておらず、リポジトリの `gitignore`（先のPRで整理したもの）も未使用のままだった。symlink先に合わせて修正し、グローバル無視が初めて機能するようにした。

### mise設定
- **不要な mise グローバル設定を削除**（`chore`）: `host-private/config/mise/config.toml`（→ `~/.config/mise/config.toml`）は node/pnpm がルート `mise.toml` と重複しており、グローバル側は不要のため削除。

### zsh起動
- **`zsh-autosuggestions` を defer 化**（`perf`）: `zsh-syntax-highlighting` と同様に遅延ロードしてシェル起動を高速化。zsh-autosuggestions を syntax-highlighting より前に置く公式推奨の順序に合わせた。

## 検証

- `plugins.toml` の TOML 妥当性を確認
- `git config -f host-private/gitconfig --get core.excludesfile` が `~/.gitignore` を返すことを確認
- 作業ツリーがクリーンで、3コミットが1ファイルずつに分かれていることを確認

## 補足

- mise グローバル設定の削除後、次回 `rcup` では既存の `~/.config/mise/config.toml` シンボリックリンクは自動削除されない。残った古いリンクは手動削除するか `rcdn` → `rcup` で貼り直す。
- 削除した mise 設定は `rcrc` の `EXCLUDES` に元々記載がないため EXCLUDES の変更は不要。


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFdetFAFH5LPa9T8c8SfZJ)_