### PR TITLE
pre-commitにshellcheck/actionlintを追加、miseをメジャー固定

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,16 @@ repos:
       - id: check-json
         exclude: -lock\.json$
 
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+
   - repo: local
     hooks:
       - id: dprint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,9 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
+        # shellcheckはzshを未サポート。pre-commitは.zshもshellと識別するため、
+        # 対象を実際のbashスクリプトに限定して誤検出を避ける。
+        files: ^scripts/.*\.sh$
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,7 @@
+# メジャー固定にして、マシン・時期によるバージョンずれ（再現性の低下）を防ぐ。
+# メジャー内の最新パッチは取り込まれる。新しいメジャーへ上げたいときはここを更新する。
 [tools]
-node = "latest"
-pre-commit = "latest"
-pnpm = "latest"
+node = "22"
+pre-commit = "4"
+pnpm = "11"
 python = "3.14"


### PR DESCRIPTION
## 概要

将来のバグを未然に防ぐための静的解析の追加と、ツールバージョンの再現性向上。これまでのレビューで直してきた `which` の不統一・クォート漏れ・ワークフローのミスといった類のバグを、今後は pre-commit で早期検出する。

## 変更点

### CI / pre-commit
- **shellcheck と actionlint を追加**（`ci`）:
  - `shellcheck`: `scripts/*.sh` を静的解析。`which` vs `command -v`、クォート漏れ、`set -e` の落とし穴などを検出。既存の `setup-claude.sh` / `update-plugins.sh` は導入時点で通過することを確認済み。
  - `actionlint`: `.github/workflows/*.yml` を静的解析。構文・式・`run:` 内シェル片のミスを検出。
  - `.zsh` ファイルは shellcheck の対象外（pre-commit が `zsh` type と識別するため）なので影響しない。

### mise
- **ツールをメジャー固定**（`chore`）: `node`/`pnpm`/`pre-commit` の `latest` をメジャー固定（`node="22"` `pnpm="11"` `pre-commit="4"`）に変更。メジャー内のパッチは追従しつつ、マシン・時期によるバージョンずれ（再現性の低下）を防ぐ。`python="3.14"` は据え置き。

## 検証

- `.pre-commit-config.yaml` の yamllint（`--strict`）通過
- `mise.toml` の TOML 妥当性を確認
- `scripts/setup-claude.sh` / `update-plugins.sh` が shellcheck をノーエラーで通過することを確認
- actionlint はローカル環境からバイナリ取得ができず未実行だが、ワークフローの `run:` は単純なコマンドのみ。本PRのCIで新hookが全ファイルを走査して確定検証される。


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFdetFAFH5LPa9T8c8SfZJ)_