### PR TITLE
check.ymlにconcurrency追加、lefthook installをmise setupタスク化

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+# 同一ブランチで新しい実行が始まったら、進行中の古い実行を打ち切る。
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Lint and test are defined as [mise](https://mise.jdx.dev/) tasks in `mise.toml`,
 
 ```zsh
 mise install        # install the pinned tools (dprint, shellcheck, actionlint, yamllint, ...)
-lefthook install    # enable the git hooks (pre-commit: lint, pre-push: test)
+mise run setup      # enable the git hooks (pre-commit: lint, pre-push: test)
 
 mise run check      # everything CI runs (lint + test)
 mise run lint       # dprint / yamllint / shellcheck / actionlint

--- a/mise.toml
+++ b/mise.toml
@@ -14,6 +14,10 @@ lefthook = "1"
 # チェックの定義はこの mise.toml が単一の真実の源。
 # CI（.github/workflows/check.yml）も lefthook も同じ `mise run` を呼ぶ。
 
+[tasks.setup]
+description = "gitフックを有効化する（初回のみ）"
+run = "lefthook install"
+
 [tasks.fmt]
 description = "dprintでフォーマットを適用する"
 run = "dprint fmt"


### PR DESCRIPTION
## 概要

mise + lefthook 移行（#139）後の小さな仕上げ。CIの無駄な重複実行を抑え、フック有効化を1コマンドにまとめる。

## 変更点

### CI
- **`check.yml` に concurrency 制御を追加**（`ci`）: 同一ブランチで新しい実行が始まったら進行中の古い実行を打ち切る（`cancel-in-progress`）。push を重ねたときの無駄な並行実行を防ぐ。

### 開発体験
- **`lefthook install` を mise の `setup` タスク化**（`chore`）: 新規clone時に `mise install && mise run setup` の2コマンドで gitフックまで有効化できる。READMEの手順も更新。

## 検証

- `yamllint --strict`（リポジトリ全体）通過
- `mise.toml` の TOML 妥当性、`setup` タスク定義を確認
- 差分は `check.yml` / `mise.toml` / `README.md` の3ファイルのみ

## 補足
- `jdx/mise-action` の SHA 固定（先の議論の項目2）は renovate に委ねる方針のため本PRには含めない。


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFdetFAFH5LPa9T8c8SfZJ)_