### PR TITLE
権限・スキル運用の整理とsembleのskill化

### DIFF
--- a/host-private/claude/settings.json
+++ b/host-private/claude/settings.json
@@ -135,7 +135,8 @@
     "crit@crit": true,
     "product-skills@claude-code-skills": true,
     "skill-scanner@skillplugs": true,
-    "dig@kuu-marketplace": true
+    "dig@kuu-marketplace": true,
+    "fix-ci@kuu-marketplace": true
   },
   "extraKnownMarketplaces": {
     "crit": {

--- a/host-private/claude/settings.json
+++ b/host-private/claude/settings.json
@@ -134,7 +134,8 @@
   "enabledPlugins": {
     "crit@crit": true,
     "product-skills@claude-code-skills": true,
-    "skill-scanner@skillplugs": true
+    "skill-scanner@skillplugs": true,
+    "dig@kuu-marketplace": true
   },
   "extraKnownMarketplaces": {
     "crit": {
@@ -153,6 +154,12 @@
       "source": {
         "source": "github",
         "repo": "skillplugs/plugins"
+      }
+    },
+    "kuu-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "fumiya-kume/claude-code"
       }
     }
   },

--- a/host-private/claude/settings.json
+++ b/host-private/claude/settings.json
@@ -119,8 +119,14 @@
       "Bash(git tag -d *)",
       "Bash(git push --force *)",
       "Bash(git push -f *)",
+      "Bash(git push *--force*)",
+      "Bash(git push * -f*)",
+      "Bash(git push * --delete*)",
+      "Bash(git push * -d *)",
+      "Bash(git push * -d)",
       "Bash(git reset --hard *)",
       "Bash(git clean -f *)",
+      "Bash(git clean *-f*)",
       "Bash(curl *)",
       "Bash(wget *)"
     ]


### PR DESCRIPTION
## Summary
- 過剰なpermission許可を見直し（`gh api`/`checkout`をask化、force-push穴埋め）
- digスキルをローカル管理からmarketplaceプラグイン（kuu-marketplace）へ移行
- memory/permission promotionのauto-triggerルールを削除（即時提案型ルールが形骸化するため）
- sembleのコード検索ルールを、axと同じ「rule=薄いルーティング／skill=詳細+evals」構成へ分離

## Test plan
- [x] `claude/rules/semble.md`のfrontmatter・yamllintがpre-commit hookを通過
- [x] `lsrc -d .`でsemble skillの新規ファイルがrcm管理対象として認識されることを確認
- [ ] semble skillのevalsをbaseline比較で実行（未実施、必要なら別途）