### PR TITLE
fix: PR作成コマンド実行時に必ず確認するよう設定を追加

### DIFF
--- a/host-private/claude/settings.json
+++ b/host-private/claude/settings.json
@@ -128,7 +128,8 @@
       "Bash(git push origin main*)",
       "Bash(git push origin master*)",
       "Bash(git push * origin main*)",
-      "Bash(git push * origin master*)"
+      "Bash(git push * origin master*)",
+      "Bash(gh pr create *)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## 概要
- `host-private/claude/settings.json` の `permissions.ask` に `Bash(gh pr create *)` を追加し、Claude Codeがauto mode等でも `gh pr create` 実行時に必ず確認プロンプトを挟むようにした

## テスト
- [x] `jq -e` でJSON構文・エントリの追加を確認済み